### PR TITLE
Update checkVersion-iOS.swift

### DIFF
--- a/checkVersion-iOS.swift
+++ b/checkVersion-iOS.swift
@@ -110,7 +110,7 @@ extension UIViewController {
         guard let appName = CheckUpdate.shared.getBundle(key: "CFBundleName") else { return } //Bundle.appName()
 
         let alertTitle = "New version"
-        let alertMessage = "A new version of \(appName) are available on AppStore. Update now!"
+        let alertMessage = "A new version of \(appName) is available on AppStore. Update now!"
 
         let alertController = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
 


### PR DESCRIPTION
typo correction.
it is a very small correction, but this object works too smoothly to let it go. 