### PR TITLE
Add support to check version on TestFlight 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Or the user can choose if they want to update now or later by calling
 CheckUpdate.shared.showUpdate(withConfirmation: true)
 ```
 
+But, if you want to check if there is a new TestFlight version to update, you can try:
+```
+CheckUpdate.shared.showUpdate(withConfirmation: true, isTestFlight: true)
+```
+
 ## Important
 
 Inside the code has a link from iTunes. There, you should pay attention and put the country where the application is available.
@@ -25,6 +30,14 @@ Like this: ``http://itunes.apple.com/<country>/lookup?bundleId=\(identifier)``
 
 *For example:*
 - *``let url = URL(string: "http://itunes.apple.com/br/lookup?bundleId=\(identifier)")``* if the application is available in Brazil
+
+And, in this [documentation](https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app) we can use:
+
+``"https://api.appstoreconnect.apple.com/v1/apps/\(identifier)/builds"``
+
+But, we need to generate a JWT Token first.
+
+To learn how to generate an acceptable token, you should use this [documentation](https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests).
 
 ## Screenshots
 

--- a/checkVersion-iOS.swift
+++ b/checkVersion-iOS.swift
@@ -76,6 +76,8 @@ class CheckUpdate: NSObject {
                             topController.showAppUpdateAlert(version: testFlightAppVersion, force: force, appURL: (info?.trackViewUrl)!, isTestFlight: self.isTestFlight)
                         }
                     }
+                }  else {
+                    print("App does not exist on \(store)")
                 }
             }
         }

--- a/checkVersion-iOS.swift
+++ b/checkVersion-iOS.swift
@@ -10,78 +10,130 @@ import Foundation
 import UIKit
 
 enum VersionError: Error {
-    case invalidBundleInfo, invalidResponse
+    case invalidBundleInfo, invalidResponse, dataError
 }
 
-class LookupResult: Decodable {
-    var results: [AppInfo]
+struct LookupResult: Decodable {
+    let data: [TestFlightInfo]?
+    let results: [AppInfo]?
 }
 
-class AppInfo: Decodable {
-    var version: String
-    var trackViewUrl: String
+struct TestFlightInfo: Decodable {
+    let type: String
+    let attributes: Attributes
 }
+
+struct Attributes: Decodable {
+    let version: String
+    let expired: String
+}
+
+struct AppInfo: Decodable {
+    let version: String
+    let trackViewUrl: String
+}
+
 
 class CheckUpdate: NSObject {
 
     static let shared = CheckUpdate()
+    var isTestFlight: Bool = false
     
-    
-    func showUpdate(withConfirmation: Bool) {
+    func showUpdate(withConfirmation: Bool, isTestFlight: Bool) {
+        self.isTestFlight = isTestFlight
         DispatchQueue.global().async {
             self.checkVersion(force : !withConfirmation)
         }
     }
-  
 
     private  func checkVersion(force: Bool) {
         if let currentVersion = self.getBundle(key: "CFBundleShortVersionString") {
-            _ = getAppInfo { (info, error) in
+            _ = getAppInfo { (data, info, error) in
+                
+                let store = self .isTestFlight ? "TestFlight" : "AppStore"
+                
+                if let error = error {
+                    print("error getting app \(store) version: ", error)
+                }
+                
                 if let appStoreAppVersion = info?.version {
-                    if let error = error {
-                        print("error getting app store version: ", error)
-                    } else if appStoreAppVersion <= currentVersion {
-                        print("Already on the last app version: ",currentVersion)
+                    if appStoreAppVersion <= currentVersion {
+                        print("Already on the last app version: ", currentVersion)
                     } else {
-                        print("Needs update: AppStore Version: \(appStoreAppVersion) > Current version: ",currentVersion)
+                        print("Needs update: \(store) Version: \(appStoreAppVersion) > Current version: ", currentVersion)
                         DispatchQueue.main.async {
                             let topController: UIViewController = (UIApplication.shared.windows.first?.rootViewController)!
-                            topController.showAppUpdateAlert(Version: (info?.version)!, Force: force, AppURL: (info?.trackViewUrl)!)
+                            topController.showAppUpdateAlert(version: appStoreAppVersion, force: force, appURL: (info?.trackViewUrl)!, isTestFlight: self.isTestFlight)
+                        }
+                    }
+                } else if let testFlightAppVersion = data?.attributes.version {
+                    if testFlightAppVersion <= currentVersion {
+                        print("Already on the last app version: ",currentVersion)
+                    } else {
+                        print("Needs update: \(store) Version: \(testFlightAppVersion) > Current version: ", currentVersion)
+                        DispatchQueue.main.async {
+                            let topController: UIViewController = (UIApplication.shared.windows.first?.rootViewController)!
+                            topController.showAppUpdateAlert(version: testFlightAppVersion, force: force, appURL: (info?.trackViewUrl)!, isTestFlight: self.isTestFlight)
                         }
                     }
                 }
             }
         }
     }
+    
+    private func getUrl(from identifier: String) -> String {
+        return isTestFlight ? "https://api.appstoreconnect.apple.com/v1/apps/\(identifier)/builds" : "http://itunes.apple.com/br/lookup?bundleId=\(identifier)"
+    }
 
-    private func getAppInfo(completion: @escaping (AppInfo?, Error?) -> Void) -> URLSessionDataTask? {
+    private func getAppInfo(completion: @escaping (TestFlightInfo?, AppInfo?, Error?) -> Void) -> URLSessionDataTask? {
     
       // You should pay attention on the country that your app is located, in my case I put Brazil */br/*
       // Você deve prestar atenção em que país o app está disponível, no meu caso eu coloquei Brasil */br/*
       
         guard let identifier = self.getBundle(key: "CFBundleIdentifier"),
-              let url = URL(string: "http://itunes.apple.com/br/lookup?bundleId=\(identifier)") else {
+              let url = URL(string: getUrl(from: identifier)) else {
                 DispatchQueue.main.async {
-                    completion(nil, VersionError.invalidBundleInfo)
+                    completion(nil, nil, VersionError.invalidBundleInfo)
                 }
                 return nil
         }
-        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
-          
+        
+        // You need to generate an authorization token to access the TestFlight versions and then you replace the ```***``` with the JWT token.
+        // Você precisa gerar um token de autorização para acessar as versões de TestFlight e depois você substitui o ```***``` com o token JWT gerado.
+        // https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests
+        
+        let authorization = "Bearer ***"
+        
+        var request = URLRequest(url: url)
+        
+        // You just need to add an authorization header if you are checking TestFlight version
+        // Você só precisa adicionar uma autorização no header se você está checando a versão de testflight
+        if self.isTestFlight {
+            request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        }
+        
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
             
                 do {
-                    if let error = error { throw error }
+                    if let error = error {
+                        print(error)
+                        throw error
+                    }
                     guard let data = data else { throw VersionError.invalidResponse }
                     
                     let result = try JSONDecoder().decode(LookupResult.self, from: data)
-                    print(result.results)
-                    guard let info = result.results.first else {
-                        throw VersionError.invalidResponse
+                    print(result)
+                    
+                    if self.isTestFlight {
+                        let info = result.data?.first
+                        completion(info, nil, nil)
+                    } else {
+                        let info = result.results?.first
+                        completion(nil, info, nil)
                     }
 
-                    completion(info, nil)
                 } catch {
-                    completion(nil, error)
+                    completion(nil, nil, error)
                 }
             }
         
@@ -106,21 +158,21 @@ class CheckUpdate: NSObject {
 }
 
 extension UIViewController {
-    @objc fileprivate func showAppUpdateAlert( Version : String, Force: Bool, AppURL: String) {
+    @objc fileprivate func showAppUpdateAlert(version : String, force: Bool, appURL: String, isTestFlight: Bool) {
         guard let appName = CheckUpdate.shared.getBundle(key: "CFBundleName") else { return } //Bundle.appName()
 
         let alertTitle = "New version"
-        let alertMessage = "A new version of \(appName) is available on AppStore. Update now!"
+        let alertMessage = "A new version of \(appName) is available on \(isTestFlight ? "TestFlight" : "AppStore"). Update now!"
 
         let alertController = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
 
-        if !Force {
+        if !force {
             let notNowButton = UIAlertAction(title: "Not now", style: .default)
             alertController.addAction(notNowButton)
         }
 
         let updateButton = UIAlertAction(title: "Update", style: .default) { (action:UIAlertAction) in
-            guard let url = URL(string: AppURL) else {
+            guard let url = URL(string: appURL) else {
                 return
             }
             if #available(iOS 10.0, *) {

--- a/checkVersion-iOS.swift
+++ b/checkVersion-iOS.swift
@@ -44,6 +44,8 @@ class CheckUpdate: NSObject {
 
     // MARK: - TestFlight variable
     var isTestFlight: Bool = false
+
+    static let appStoreId = "6446998023" // Id Example
     
     // MARK: - Show Update Function
     func showUpdate(withConfirmation: Bool, isTestFlight: Bool = false) {
@@ -98,7 +100,7 @@ class CheckUpdate: NSObject {
     private func getUrl(from identifier: String) -> String {
         // You should pay attention on the country that your app is located, in my case I put Brazil */br/*
         // Você deve prestar atenção em que país o app está disponível, no meu caso eu coloquei Brasil */br/*
-        let testflightURL = "https://api.appstoreconnect.apple.com/v1/apps/\(identifier)/builds"
+        let testflightURL = "https://api.appstoreconnect.apple.com/v1/apps/\(appStoreId)/builds"
         let appStoreURL = "http://itunes.apple.com/br/lookup?bundleId=\(identifier)"
 
         return isTestFlight ? testflightURL : appStoreURL


### PR DESCRIPTION
Issue reported by @eonist on #4 

### What to do
Add support to check version on TestFlight.

### Documentation used
https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app
https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests


### What was done
Added new models to get data from TestFlight.
Added a check if it is TestFlight.
Inform when app is not on the store
Added a `URLRequest` to set an Authorization